### PR TITLE
Update morgan.codes-color-theme.json

### DIFF
--- a/themes/morgan.codes-color-theme.json
+++ b/themes/morgan.codes-color-theme.json
@@ -27,6 +27,7 @@
 
 		// Status bar
 		"statusBar.background": "#fc4384",
+		"statusBar.noFolderBackground" : "#fc4384",
 		"statusBar.foreground": "#ffffff",
 		"statusBar.border": "#080808",
 


### PR DESCRIPTION
Added the line "statusBar.noFolderBackground" : "#fc4384" to set the color of the status bar when there are no folders opened